### PR TITLE
zip -> itertools.zip_longest

### DIFF
--- a/tests/test_fizzbuzz.py
+++ b/tests/test_fizzbuzz.py
@@ -1,3 +1,5 @@
+from itertools import zip_longest
+
 import fzbz as fizzbuzz
 
 FIZZ_BUZZ = [
@@ -105,6 +107,6 @@ FIZZ_BUZZ = [
 
 
 def test_all():
-    for x, y in zip(fizzbuzz, FIZZ_BUZZ):
+    for x, y in zip_longest(fizzbuzz, FIZZ_BUZZ, fillvalue=None):
         assert x is not None
         assert x == y


### PR DESCRIPTION
`zip` stops whenever one of its iterables is exhausted, so that the current test passes as long as `FIZZ_BUZZ` is any initial slice of the right answers. (for example, if it were an empty list, the test would still pass)

`itertools.zip_longest` gives you the behavior (I assume) you intended